### PR TITLE
Made CI/CD only run on specific path push and added 2 more helping workflows

### DIFF
--- a/.github/workflows/pipeline-cicd.yml
+++ b/.github/workflows/pipeline-cicd.yml
@@ -5,7 +5,10 @@ on:
   push:
     branches:
       - main
-    workflow_dispatch:
+    paths:
+      - 'planner-backend/**'
+      - 'planner-frontend/**'
+  workflow_dispatch:
 
 permissions:
   contents: write
@@ -14,10 +17,6 @@ jobs:
   build-back:
     runs-on: self-hosted
     steps:
-
-      - name: Debug username
-        run: whoami
-
       - name: Checkout
         uses: actions/checkout@v4
 

--- a/.github/workflows/purge-containers.yml
+++ b/.github/workflows/purge-containers.yml
@@ -1,0 +1,28 @@
+name: Purge Containers
+
+on:
+  workflow_dispatch:
+
+  jobs:
+    purge-containers:
+      runs-on: self-hosted
+      steps:
+        - name: Cleanup unused containers
+          run: |
+            echo "Purging containers..."
+            docker container prune -f
+
+        - name: Cleanup unused images
+          run: |
+            echo "Purging images..."
+            docker image prune -f
+        
+        - name: Cleanup unused volumes
+          run: |
+            echo "Purging volumes..."
+            docker volume prune -f
+        
+        - name: Cleanup unused networks
+          run: |
+            echo "Purging networks..."
+            docker network prune -f

--- a/.github/workflows/stop-alles.yml
+++ b/.github/workflows/stop-alles.yml
@@ -1,0 +1,16 @@
+name: Stop Alles Containers
+
+on:
+  workflow_dispatch:
+
+  jobs:
+    stop-backend:
+      runs-on: self-hosted
+      steps:
+        - name: Checkout
+          uses: actions/checkout@v4
+
+        - name: Stop container
+          run: |
+            echo "Stopping the container..."
+            docker compose -f shichtconfig/docker/docker-compose-test.yml down || true


### PR DESCRIPTION
This PR description was fully written by copilot to ease out the summary process. Do  mind it is written by AI.

This pull request includes updates to the CI/CD pipeline configuration in the `.github/workflows/pipeline-cicd.yml` file. The changes focus on specifying paths for triggering the pipeline and cleaning up unnecessary steps in the build job.

Updates to CI/CD pipeline configuration:

* [`.github/workflows/pipeline-cicd.yml`](diffhunk://#diff-871dd311bc0ed655a4093affb41ba95948cd9e2a3258e8745d20dfd4724a54f3R8-R10): Added specific paths (`planner-backend/**` and `planner-frontend/**`) to trigger the pipeline only when changes occur in these directories.
* [`.github/workflows/pipeline-cicd.yml`](diffhunk://#diff-871dd311bc0ed655a4093affb41ba95948cd9e2a3258e8745d20dfd4724a54f3L17-L20): Removed the debug step that prints the username to streamline the build process.…rkfows
This pull request includes updates to the GitHub Actions workflows to enhance the CI/CD pipeline and add new maintenance workflows. The most important changes include adding path filters to the pipeline trigger, removing unnecessary debug steps, and introducing workflows for purging containers and stopping backend containers.

Enhancements to CI/CD pipeline:

* [`.github/workflows/pipeline-cicd.yml`](diffhunk://#diff-871dd311bc0ed655a4093affb41ba95948cd9e2a3258e8745d20dfd4724a54f3R8-R10): Added path filters to trigger the pipeline only when changes are made in `planner-backend` or `planner-frontend` directories.
* [`.github/workflows/pipeline-cicd.yml`](diffhunk://#diff-871dd311bc0ed655a4093affb41ba95948cd9e2a3258e8745d20dfd4724a54f3L17-L20): Removed unnecessary debug steps from the `build-back` job to streamline the process.

New maintenance workflows:

* [`.github/workflows/purge-containers.yml`](diffhunk://#diff-3f0fb0bf240538e2e2c4a03c64f86e486d5960a82a950994b2ee62908fe0c9feR1-R28): Introduced a new workflow to purge unused Docker containers, images, volumes, and networks.
* [`.github/workflows/stop-alles.yml`](diffhunk://#diff-7fb98b7ee542dbf8322db789f77a76b7cfd8400bb53f03f6b2ca72993751447aR1-R16): Added a workflow to stop backend containers using Docker Compose.