### PR TITLE
Fixed tokens + made more automation + fixed database

### DIFF
--- a/planner-backend/modules/auth/src/main/java/com/LIT/auth/service/AuthenticationService.java
+++ b/planner-backend/modules/auth/src/main/java/com/LIT/auth/service/AuthenticationService.java
@@ -154,7 +154,7 @@ public class AuthenticationService {
         log.info(logHeader + "login: User found. Generating token...");
 
         // Generate token
-        String token = "Bearer: " + jwtTokenUtil.generateToken(user.getEmail(), role);
+        String token = "Bearer " + jwtTokenUtil.generateToken(user.getEmail(), role);
 
          Map<String, String> toReturn = new HashMap<>();
             toReturn.put("token", token);

--- a/planner-backend/modules/logicGate/src/main/java/com/LIT/logicGate/utilities/JwtAuthenticationFilter.java
+++ b/planner-backend/modules/logicGate/src/main/java/com/LIT/logicGate/utilities/JwtAuthenticationFilter.java
@@ -66,11 +66,11 @@ public class JwtAuthenticationFilter extends OncePerRequestFilter {
         }
 
         // there IS a token -> Accessed after system auth -> IN system
-        if (authHeader.startsWith("Bearer: ")) {
+        if (authHeader.startsWith("Bearer ")) {
             // Analyze token's validity
             log.info(logHeader + "Token provided, checking validity");
 
-            String token = authHeader.substring(8); //remove "Bearer " prefix
+            String token = authHeader.substring(7); //remove "Bearer " prefix
 
             if (!jwtTokenUtil.validateToken(token)) {
                 log.error(logHeader + "Invalid token provided, rejecting request");

--- a/planner-backend/modules/scheduler/src/main/java/com/LIT/scheduler/controller/ShiftAssignmentController.java
+++ b/planner-backend/modules/scheduler/src/main/java/com/LIT/scheduler/controller/ShiftAssignmentController.java
@@ -30,6 +30,7 @@ public class ShiftAssignmentController {
         this.shiftAssignmentService = shiftAssignmentService;
     }
 
+    // Test JWT -> Button on front-end to check privileges
     @GetMapping("/test-jwt")
     public ResponseEntity<String> testJwt() {
         log.info(logHeader + "testJwt: JWT is working!");

--- a/planner-backend/modules/scheduler/src/main/java/com/LIT/scheduler/controller/ShiftController.java
+++ b/planner-backend/modules/scheduler/src/main/java/com/LIT/scheduler/controller/ShiftController.java
@@ -52,7 +52,7 @@ public class ShiftController {
                     .orElseGet(() -> ResponseEntity.notFound().build());
     }
 
-    @PostMapping
+    @PostMapping("/create")
     public Shift createShift(@RequestBody Shift shift) {
         log.info(logHeader + "createShift: Creating new shift");
         return shiftService.saveShift(shift);

--- a/planner-backend/modules/scheduler/src/main/java/com/LIT/scheduler/model/entity/Shift.java
+++ b/planner-backend/modules/scheduler/src/main/java/com/LIT/scheduler/model/entity/Shift.java
@@ -1,8 +1,18 @@
 package com.LIT.scheduler.model.entity;
 
 import java.time.LocalDateTime;
-import jakarta.persistence.*;
-import lombok.*;
+
+import jakarta.persistence.Column;
+import jakarta.persistence.Entity;
+import jakarta.persistence.GeneratedValue;
+import jakarta.persistence.GenerationType;
+import jakarta.persistence.Id;
+import jakarta.persistence.Table;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import lombok.Setter;
 
 @Entity
 @Getter

--- a/planner-backend/modules/statistics/src/main/java/com/LIT/statistics/controller/StatisticsController.java
+++ b/planner-backend/modules/statistics/src/main/java/com/LIT/statistics/controller/StatisticsController.java
@@ -12,11 +12,20 @@ import lombok.extern.slf4j.Slf4j;
 
 @RestController
 @RequestMapping("/api/stats")
+@Slf4j
 public class StatisticsController {
+
+    private final String logHeader = "[StatisticsController] - ";
 
     @GetMapping("/hello")
     public ResponseEntity<String> hello() {
         return ResponseEntity.ok("Hello from statistics module!");
+    }
+
+    @GetMapping("/test-jwt")
+    public ResponseEntity<String> testJwt() {
+        log.info(logHeader + "testJwt: JWT is working!");
+        return ResponseEntity.ok("JWT is working!");
     }
     
 }

--- a/schichtconfig/docker/README.md
+++ b/schichtconfig/docker/README.md
@@ -3,6 +3,12 @@ The docker-compose in this file includes a MariaDB image, which establishes the 
 
 # Docker commands for server
 ## Specific commands
+
+### Find docker compose file location
+```bash
+find / -name docker-compose.yml 2>/dev/null
+```
+
 ### Check live status for all containers
 ```bash
 docker stats


### PR DESCRIPTION
This pull request includes several changes across different modules to improve token handling, add new endpoints, and enhance documentation. The most important changes include updating token handling in the authentication service and JWT filter, adding test JWT endpoints, and modifying the shift creation endpoint.

### Token Handling Improvements:
* [`planner-backend/modules/auth/src/main/java/com/LIT/auth/service/AuthenticationService.java`](diffhunk://#diff-2142179ba3992c1d6024705f312286cf76460a3e1a73e43087aa4f3919137700L157-R157): Updated the token generation format by removing the colon after "Bearer".
* [`planner-backend/modules/logicGate/src/main/java/com/LIT/logicGate/utilities/JwtAuthenticationFilter.java`](diffhunk://#diff-c6cb6ca20ddebbffef649ebb0738063c97986796c04bbf2c3f2c8e11ebaccac5L69-R73): Modified the token validation logic to match the new token format without the colon.

### New Endpoints:
* [`planner-backend/modules/scheduler/src/main/java/com/LIT/scheduler/controller/ShiftAssignmentController.java`](diffhunk://#diff-5d3f5022fa927677c884131b38c7eede31a5a1eb74c35ed6ec3c0614b5891414R33): Added a new endpoint `/test-jwt` to test JWT functionality.
* [`planner-backend/modules/statistics/src/main/java/com/LIT/statistics/controller/StatisticsController.java`](diffhunk://#diff-a730b7f014ad1b2884df75310d7d82a7d4123ec91db8acf7bac3b19af3cca6acR15-R30): Added a new endpoint `/test-jwt` for JWT testing and included logging.

### Endpoint Modification:
* [`planner-backend/modules/scheduler/src/main/java/com/LIT/scheduler/controller/ShiftController.java`](diffhunk://#diff-99a8081f5e66742d8cab93ff076ebed46de4eb4aed82fed58c1e312661481458L55-R55): Changed the endpoint for creating a shift from `/` to `/create`.

### Code Organization:
* [`planner-backend/modules/scheduler/src/main/java/com/LIT/scheduler/model/entity/Shift.java`](diffhunk://#diff-9763ab167819aedfb185e03112f54d8d95999d6f88c962ffbbe663c7903b48f2L4-R15): Reorganized import statements for better readability.

### Documentation:
* [`schichtconfig/docker/README.md`](diffhunk://#diff-429d2fccb88d89a9b5825615f59c9f64c7e7ca19e44b8fd76de355e9a480b923R6-R11): Added a command to find the location of the docker-compose file.