### PR TITLE
Javier -> Functioning shift proposals

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,5 @@
+commit_all.bat
+
 .mvn/timing.properties
 .mvn/wrapper/maven-wrapper.jar
 

--- a/planner-backend/modules/auth/pom.xml
+++ b/planner-backend/modules/auth/pom.xml
@@ -25,6 +25,17 @@
             <groupId>org.springframework.boot</groupId>
             <artifactId>spring-boot-starter-data-jpa</artifactId>
         </dependency>
+        
+        <!-- Jackson stuff -->
+        <dependency>
+          <groupId>com.fasterxml.jackson.core</groupId>
+          <artifactId>jackson-databind</artifactId>
+        </dependency>
+
+        <dependency>
+          <groupId>com.fasterxml.jackson.datatype</groupId>
+          <artifactId>jackson-datatype-jsr310</artifactId>
+        </dependency>
 
         <!-- MariaDB Dependency -->
         <dependency>

--- a/planner-backend/modules/logicGate/pom.xml
+++ b/planner-backend/modules/logicGate/pom.xml
@@ -25,6 +25,17 @@
       <groupId>org.springframework.boot</groupId>
       <artifactId>spring-boot-starter-data-jpa</artifactId>
     </dependency>
+    
+    <!-- Jackson stuff -->
+    <dependency>
+      <groupId>com.fasterxml.jackson.core</groupId>
+      <artifactId>jackson-databind</artifactId>
+    </dependency>
+
+    <dependency>
+      <groupId>com.fasterxml.jackson.datatype</groupId>
+      <artifactId>jackson-datatype-jsr310</artifactId>
+    </dependency>
 
     <!-- MariaDB Dependency -->
     <dependency>

--- a/planner-backend/modules/scheduler/pom.xml
+++ b/planner-backend/modules/scheduler/pom.xml
@@ -26,6 +26,18 @@
       <artifactId>spring-boot-starter-data-jpa</artifactId>
     </dependency>
 
+
+    <!-- Jackson stuff -->
+    <dependency>
+      <groupId>com.fasterxml.jackson.core</groupId>
+      <artifactId>jackson-databind</artifactId>
+    </dependency>
+
+    <dependency>
+      <groupId>com.fasterxml.jackson.datatype</groupId>
+      <artifactId>jackson-datatype-jsr310</artifactId>
+    </dependency>
+
     <!-- MariaDB Dependency -->
     <dependency>
       <groupId>org.mariadb.jdbc</groupId>

--- a/planner-backend/modules/scheduler/src/main/java/com/LIT/scheduler/controller/ShiftProposalController.java
+++ b/planner-backend/modules/scheduler/src/main/java/com/LIT/scheduler/controller/ShiftProposalController.java
@@ -2,24 +2,33 @@ package com.LIT.scheduler.controller;
 
 import com.LIT.scheduler.model.entity.ShiftProposal;
 import com.LIT.scheduler.service.ShiftProposalService;
+
+import lombok.extern.slf4j.Slf4j;
+
+import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.*;
 
 import java.util.List;
 
+@Slf4j
 @RestController
 @RequestMapping("/api/scheduler/shift-proposals")
 public class ShiftProposalController {
 
     private final ShiftProposalService proposalService;
 
+    private final static String logHeader = "[ShiftProposalController] - ";
+
+    @Autowired
     public ShiftProposalController(ShiftProposalService proposalService) {
         this.proposalService = proposalService;
     }
 
     // Employee submits new shift proposal
-    @PostMapping
+    @PostMapping("/create")
     public ResponseEntity<ShiftProposal> createProposal(@RequestBody ShiftProposal proposal) {
+        log.info(logHeader + "createProposal: Creating new shift proposal");
         ShiftProposal savedProposal = proposalService.createProposal(proposal);
         return ResponseEntity.ok(savedProposal);
     }
@@ -27,13 +36,16 @@ public class ShiftProposalController {
     // Employee retrieves their proposal
     @GetMapping("/employee/{employeeId}")
     public ResponseEntity<List<ShiftProposal>> getProposalsByEmployee(@PathVariable Long employeeId) {
+        log.info(logHeader + "getProposalsByEmployee: Getting proposals for employee with id: " + employeeId);
         List<ShiftProposal> proposals = proposalService.getProposalsByEmployee(employeeId);
+
         return ResponseEntity.ok(proposals);
     }
 
     // Manager retrieves all proposals
     @GetMapping
     public ResponseEntity<List<ShiftProposal>> getAllProposals() {
+        log.info(logHeader + "getAllProposals: Getting all proposals");
         List<ShiftProposal> proposals = proposalService.getAllProposals();
         return ResponseEntity.ok(proposals);
     }
@@ -41,6 +53,7 @@ public class ShiftProposalController {
     // Manager accepts proposal
     @PutMapping("/{proposalId}/accept")
     public ResponseEntity<ShiftProposal> acceptProposal(@PathVariable Long proposalId) {
+        log.info(logHeader + "Manager accepted proposal with id: " + proposalId);
         ShiftProposal updatedProposal = proposalService.acceptProposal(proposalId);
         return ResponseEntity.ok(updatedProposal);
     }
@@ -49,6 +62,7 @@ public class ShiftProposalController {
     @PutMapping("/{proposalId}/reject")
     public ResponseEntity<ShiftProposal> rejectProposal(@PathVariable Long proposalId,
                                                         @RequestBody(required = false) String managerComment) {
+        log.info(logHeader + "Manager rejected proposal with id: " + proposalId);
         ShiftProposal updatedProposal = proposalService.rejectProposal(proposalId, managerComment);
         return ResponseEntity.ok(updatedProposal);
     }
@@ -57,6 +71,7 @@ public class ShiftProposalController {
     @PutMapping("/{proposalId}/alternative")
     public ResponseEntity<ShiftProposal> proposeAlternative(@PathVariable Long proposalId,
                                                             @RequestBody ShiftProposal alternativeDetails) {
+        log.info(logHeader + "Manager proposed alternative for proposal with id: " + proposalId);
         ShiftProposal updatedProposal = proposalService.proposeAlternative(proposalId, alternativeDetails);
         return ResponseEntity.ok(updatedProposal);
     }

--- a/planner-backend/modules/scheduler/src/main/java/com/LIT/scheduler/model/repository/ShiftProposalRepository.java
+++ b/planner-backend/modules/scheduler/src/main/java/com/LIT/scheduler/model/repository/ShiftProposalRepository.java
@@ -2,8 +2,14 @@ package com.LIT.scheduler.model.repository;
 
 import com.LIT.scheduler.model.entity.ShiftProposal;
 import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Query;
+import org.springframework.stereotype.Repository;
+
 import java.util.List;
 
+@Repository
 public interface ShiftProposalRepository extends JpaRepository<ShiftProposal, Long> {
+
+    @Query("SELECT sp FROM ShiftProposal sp WHERE sp.employeeId = ?1")
     List<ShiftProposal> findByEmployeeId(Long employeeId);
 }

--- a/planner-backend/modules/scheduler/src/main/java/com/LIT/scheduler/service/ShiftProposalService.java
+++ b/planner-backend/modules/scheduler/src/main/java/com/LIT/scheduler/service/ShiftProposalService.java
@@ -9,6 +9,8 @@ import com.LIT.scheduler.model.repository.ShiftAssignmentRepository;
 import com.LIT.scheduler.model.repository.ShiftProposalRepository;
 import com.LIT.scheduler.model.repository.ShiftRepository;
 import lombok.extern.slf4j.Slf4j;
+
+import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.stereotype.Service;
 
 import java.time.LocalDateTime;
@@ -26,6 +28,7 @@ public class ShiftProposalService {
 
     private final String logHeader = "[ShiftProposalService] - ";
 
+    @Autowired
     public ShiftProposalService(ShiftProposalRepository proposalRepository,
                                 ShiftRepository shiftRepository,
                                 ShiftAssignmentService assignmentService,
@@ -38,35 +41,46 @@ public class ShiftProposalService {
 
     // Employee submits new shift proposal (now with conflict detection)
     public ShiftProposal createProposal(ShiftProposal proposal) {
+        log.info(logHeader + "createProposal: Creating new shift proposal");
+
         // Check if there is a conflict with existing official assignments for this specific employee
         LocalDateTime proposedStart = proposal.getProposedStartTime();
 
         LocalDateTime proposedEnd = proposal.getProposedEndTime();
 
-        List<ShiftAssignment> conflicts = assignmentRepository.findConflictingAssignments(
-                proposal.getEmployeeId(), proposedStart, proposedEnd);
+        log.info(logHeader + "Checking for conflicts with existing official assignments for employee: " + proposal.getEmployeeId() + " from: " + proposedStart + " to: " + proposedEnd);
+                
+        List<ShiftAssignment> conflicts = assignmentRepository.findConflictingAssignments(proposal.getEmployeeId(), proposedStart, proposedEnd);
         
         if (!conflicts.isEmpty()) {
-            log.error("Conflict detected: Employee {} has an official assignment overlapping with the proposed shift ({} - {}).",
-                    proposal.getEmployeeId(), proposedStart, proposedEnd);
-
+            log.error(logHeader + "Conflict detected: Employee " + proposal.getEmployeeId() + " has an official assignment overlapping with the proposed shift (" + proposedStart + " to " + proposedEnd + ")");
             throw new ShiftConflictException("Cannot propose shift: The proposed time overlaps with an existing official shift.");
+        } else {
+            log.info(logHeader + "No conflicts detected for employee " + proposal.getEmployeeId() + " from " + proposedStart + " to " + proposedEnd + ". Proceeding with proposal creation.");
         }
         
         proposal.setStatus(ShiftProposalStatus.PROPOSED);
-        log.info(logHeader + "Employee {} submitted a shift proposal: {} from {} to {}",
-                proposal.getEmployeeId(), proposal.getProposedTitle(), proposedStart, proposedEnd);
-        return proposalRepository.save(proposal);
+
+        proposalRepository.save(proposal);
+        log.info(logHeader + "Employee " + proposal.getEmployeeId() + " has proposed a new shift: " + proposal.getProposedTitle() + " from " + proposal.getProposedStartTime() + " to " + proposal.getProposedEndTime());
+        
+        return proposal;
     }
 
     // Manager accepts a proposal
     public ShiftProposal acceptProposal(Long proposalId) {
+        log.info(logHeader + "Manager is accepting proposal {}.", proposalId);
+
         Optional<ShiftProposal> opt = proposalRepository.findById(proposalId);
+
         if (!opt.isPresent()) {
             throw new IllegalArgumentException("Shift proposal not found.");
         }
+
         ShiftProposal proposal = opt.get();
+
         proposal.setStatus(ShiftProposalStatus.ACCEPTED);
+
         // Convert proposal to an official shift and create an assignment.
         Shift newShift = Shift.builder()
                 .title(proposal.getProposedTitle())
@@ -74,45 +88,64 @@ public class ShiftProposalService {
                 .endTime(proposal.getProposedEndTime())
                 .build();
         newShift = shiftRepository.save(newShift);
+
+        log.info(logHeader + "Official shift created: {} from {} to {}",
+                newShift.getId(), newShift.getStartTime(), newShift.getEndTime());
+
         ShiftAssignment assignment = ShiftAssignment.builder()
                 .userId(proposal.getEmployeeId())
                 .shift(newShift)
                 .status(com.LIT.scheduler.model.enums.AssignmentStatus.CONFIRMED)
                 .build();
+
         assignmentService.assignShift(assignment);
         log.info(logHeader + "Manager accepted proposal {}. Official shift {} created for employee {}.",
                 proposalId, newShift.getId(), proposal.getEmployeeId());
+
         return proposalRepository.save(proposal);
     }
 
     // Manager rejects a proposal without an alternative
     public ShiftProposal rejectProposal(Long proposalId, String managerComment) {
+        log.info(logHeader + "Manager is rejecting proposal {}.", proposalId);
         Optional<ShiftProposal> opt = proposalRepository.findById(proposalId);
+
         if (!opt.isPresent()) {
             throw new IllegalArgumentException("Shift proposal not found.");
         }
+
         ShiftProposal proposal = opt.get();
+
         proposal.setStatus(ShiftProposalStatus.REJECTED);
         proposal.setManagerComment(managerComment);
+
         log.info(logHeader + "Manager rejected proposal {} for employee {}.", proposalId, proposal.getEmployeeId());
+
         return proposalRepository.save(proposal);
     }
 
     // Manager rejects a proposal and proposes an alternative
     public ShiftProposal proposeAlternative(Long proposalId, ShiftProposal alternativeDetails) {
+        log.info(logHeader + "Manager is proposing an alternative for proposal {}.", proposalId);
+
         Optional<ShiftProposal> opt = proposalRepository.findById(proposalId);
+
         if (!opt.isPresent()) {
             throw new IllegalArgumentException("Shift proposal not found.");
         }
+        
         ShiftProposal proposal = opt.get();
+        
         proposal.setStatus(ShiftProposalStatus.ALTERNATIVE_PROPOSED);
         proposal.setManagerAlternativeTitle(alternativeDetails.getProposedTitle());
         proposal.setManagerAlternativeStartTime(alternativeDetails.getProposedStartTime());
         proposal.setManagerAlternativeEndTime(alternativeDetails.getProposedEndTime());
         proposal.setManagerComment(alternativeDetails.getManagerComment());
+        
         log.info(logHeader + "Manager proposed an alternative for proposal {}. Alternative shift: {} from {} to {}.",
                 proposalId, alternativeDetails.getProposedTitle(),
                 alternativeDetails.getProposedStartTime(), alternativeDetails.getProposedEndTime());
+        
         return proposalRepository.save(proposal);
     }
 

--- a/planner-backend/modules/statistics/pom.xml
+++ b/planner-backend/modules/statistics/pom.xml
@@ -26,6 +26,17 @@
       <artifactId>spring-boot-starter-data-jpa</artifactId>
     </dependency>
 
+    <!-- Jackson stuff -->
+    <dependency>
+      <groupId>com.fasterxml.jackson.core</groupId>
+      <artifactId>jackson-databind</artifactId>
+    </dependency>
+
+    <dependency>
+      <groupId>com.fasterxml.jackson.datatype</groupId>
+      <artifactId>jackson-datatype-jsr310</artifactId>
+    </dependency>
+
     <!-- MariaDB Dependency -->
     <dependency>
       <groupId>org.mariadb.jdbc</groupId>

--- a/planner-backend/pom.xml
+++ b/planner-backend/pom.xml
@@ -36,6 +36,19 @@
                 <version>${springboot.version}</version>
             </dependency>
 
+            <!-- Jackson stuff -->
+            <dependency>
+                <groupId>com.fasterxml.jackson.core</groupId>
+                <artifactId>jackson-databind</artifactId>
+                <version>2.18.2</version>
+            </dependency>
+
+            <dependency>
+                <groupId>com.fasterxml.jackson.datatype</groupId>
+                <artifactId>jackson-datatype-jsr310</artifactId>
+                <version>2.18.2</version>
+            </dependency>
+
             <!-- MariaDB Dependency -->
             <dependency>
                 <groupId>org.mariadb.jdbc</groupId>


### PR DESCRIPTION
This pull request includes several changes to the `planner-backend` project, primarily focusing on adding Jackson dependencies to multiple `pom.xml` files and enhancing logging and functionality within the `ShiftProposalController` and related services.

### Dependency Additions:
* Added `jackson-databind` and `jackson-datatype-jsr310` dependencies to `planner-backend/pom.xml` and module-specific `pom.xml` files to support JSON processing. [[1]](diffhunk://#diff-e184c43b5ca84c9d289f1eb3620ca04de510a8af99bc3454ee8a27312e916682R29-R39) [[2]](diffhunk://#diff-d54ec0acce0804eb2fc60c12a1f962427d8e4c0fc94e66d09788f27c054e2167R29-R39) [[3]](diffhunk://#diff-7ac8a0c9acca6237bf72a9730fa74bafe99af9d5b4e59980a213b7edb2153322R29-R40) [[4]](diffhunk://#diff-bc396748471d03f3218c1da55360400687c7d7faf39c39fef93ff50056856235R29-R39) [[5]](diffhunk://#diff-903cdca46fbb49779105719536288e2e89b560adc335873966d829e63abbc834R39-R51)

### Logging Enhancements:
* Enhanced logging in `ShiftProposalController` by adding log statements to key methods for better traceability. [[1]](diffhunk://#diff-3a115c8b42e663464046b2a5a6df767db1c721152e171f5972c1f324cc792251R5-R56) [[2]](diffhunk://#diff-3a115c8b42e663464046b2a5a6df767db1c721152e171f5972c1f324cc792251R65) [[3]](diffhunk://#diff-3a115c8b42e663464046b2a5a6df767db1c721152e171f5972c1f324cc792251R74)
* Improved logging in `ShiftProposalService` to provide detailed information about shift proposal processing and conflict detection. [[1]](diffhunk://#diff-044d6f41c37664af81ac185b8be10d6d107de1c5cdd06b5c4b02984787f7e461R44-R148) [[2]](diffhunk://#diff-044d6f41c37664af81ac185b8be10d6d107de1c5cdd06b5c4b02984787f7e461R31)

### Repository and Service Updates:
* Annotated `ShiftProposalRepository` with `@Repository` and added a custom query to find proposals by employee ID.
* Updated `ShiftProposalService` to include logging and handle conflicts more effectively during shift proposal creation. [[1]](diffhunk://#diff-044d6f41c37664af81ac185b8be10d6d107de1c5cdd06b5c4b02984787f7e461R12-R13) [[2]](diffhunk://#diff-044d6f41c37664af81ac185b8be10d6d107de1c5cdd06b5c4b02984787f7e461R44-R148)