### PR TITLE
Added access control + tests in auth module

### DIFF
--- a/planner-backend/modules/auth/src/main/java/com/LIT/auth/controller/UserController.java
+++ b/planner-backend/modules/auth/src/main/java/com/LIT/auth/controller/UserController.java
@@ -9,6 +9,7 @@ import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.PathVariable;
 import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.RequestBody;
+import org.springframework.web.bind.annotation.RequestHeader;
 import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RestController;
 
@@ -32,26 +33,55 @@ public class UserController {
     @GetMapping
     public List<User> getAllUsers() {
         log.info(logHeader + "getAllUsers: Getting all users");
+
         return userService.getAllUsers();
     }
 
-    @GetMapping("/{id}")
-    public ResponseEntity<User> getUserById(@PathVariable Long id) {
+    @GetMapping("/{id}")    
+    public ResponseEntity<User> getUserById(@PathVariable Long id, @RequestHeader("X-User-Role") String role) {
         log.info(logHeader + "getUserById: Getting user by id: " + id);
+
+        if(role == null) {
+            log.error(logHeader + "getUserById: User role is not provided in the header");
+
+            return ResponseEntity.badRequest().build();
+        }
+
+        if(!role.equals("ROLE_Admin") && !role.equals("ROLE_ShiftSupervisor")) {
+            log.error(logHeader + "getUserById: User does not have permission to get user by id. The user role is: " + role);
+
+            return ResponseEntity.badRequest().build();
+        }
+
         Optional<User> user = userService.getUserById(id);
+
         return user.map(ResponseEntity::ok).orElseGet(() -> ResponseEntity.notFound().build());
     }
 
-    @PostMapping
+    @PostMapping    
     public User createUser(@RequestBody User user) {
         log.info(logHeader + "createUser: Creating user: " + user);
+        
         return userService.saveUser(user);
     }
 
     @DeleteMapping("/{id}")
-    public ResponseEntity<Void> deleteUser(@PathVariable Long id) {
+    public ResponseEntity<Void> deleteUser(@PathVariable Long id, @RequestHeader("X-User-Role") String role) {
         log.info(logHeader + "deleteUser: Deleting user by id: " + id);
+
+        if(role == null) {
+            log.error(logHeader + "getUserById: User role is not provided in the header");
+
+            return ResponseEntity.badRequest().build();
+        }
+
+        if(!role.equals("ROLE_Admin")) {
+            log.error(logHeader + "deleteUser: User does not have permission to delete user. The user role is: " + role);
+            return ResponseEntity.badRequest().build();
+        }
+
         userService.deleteUser(id);
+        
         return ResponseEntity.noContent().build();
     }
 }

--- a/planner-backend/modules/auth/src/test/java/com/LIT/auth/AuthApplicationTest.java
+++ b/planner-backend/modules/auth/src/test/java/com/LIT/auth/AuthApplicationTest.java
@@ -1,0 +1,5 @@
+package com.LIT.auth;
+
+public class AuthApplicationTest {
+    
+}

--- a/planner-backend/modules/auth/src/test/java/com/LIT/auth/tests/controller/UserControllerTest.java
+++ b/planner-backend/modules/auth/src/test/java/com/LIT/auth/tests/controller/UserControllerTest.java
@@ -1,0 +1,113 @@
+package com.LIT.auth.tests.controller;
+
+import com.LIT.auth.controller.UserController;
+import com.LIT.auth.service.UserService;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.mockito.Mockito;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.autoconfigure.web.servlet.AutoConfigureMockMvc;
+import org.springframework.boot.test.autoconfigure.web.servlet.WebMvcTest;
+import org.springframework.boot.test.mock.mockito.MockBean;
+import org.springframework.test.web.servlet.MockMvc;
+
+import static org.mockito.ArgumentMatchers.anyLong;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.delete;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
+
+import java.util.Optional;
+
+@WebMvcTest(UserController.class)
+@AutoConfigureMockMvc(addFilters = false)
+class UserControllerTest {
+
+    @Autowired
+    private MockMvc mockMvc;
+
+    // Mock your service so there's no DB interaction
+    @MockBean
+    private UserService userService;
+
+    /*
+     * Test user deletion (Only Admin can delete users)
+     */
+    // Test the delete user endpoint -> with ADMIN (should succeed)
+    @Test
+    @DisplayName("DELETE /api/auth/users/{id} with ROLE_Admin should succeed")
+    void deleteUserAsAdminShouldReturnNoContent() throws Exception {
+        // Given: we do not actually perform deletion, so mock it to do nothing
+        Mockito.doNothing().when(userService).deleteUser(anyLong());
+
+        // When & Then
+        mockMvc.perform(
+                delete("/api/auth/users/{id}", 1L)
+                  .header("X-User-Role", "ROLE_Admin")
+        )
+        .andExpect(status().isNoContent());
+    }
+
+    // Test the delete user endpoint -> with ShiftSupervisor (should fail)
+    @Test
+    @DisplayName("DELETE /api/auth/users/{id} with ROLE_ShiftSupervisor should fail with 400")
+    void deleteUserAsShiftSupervisorShouldReturnBadRequest() throws Exception {
+        // Given: same mocking, still do nothing
+        Mockito.doNothing().when(userService).deleteUser(anyLong());
+
+        // When & Then
+        mockMvc.perform(
+                delete("/api/auth/users/{id}", 1L)
+                  .header("X-User-Role", "ROLE_ShiftSupervisor")
+        )
+        .andExpect(status().isBadRequest());
+    }
+
+    /*
+     * Test getting user info (Only Admin & ShiftSupervisor can get user info)
+     */
+    // Test getting user info -> with Admin (should succeed)
+    @Test
+    @DisplayName("GET /api/auth/users/{id} with ROLE_Admin should succeed")
+    void getUserInfoAsAdminShouldReturnOk() throws Exception {
+        // Given: mock the user service to return an empty optional
+        Mockito.when(userService.getUserById(anyLong())).thenReturn(Optional.empty());
+
+        // When & Then
+        mockMvc.perform(
+                get("/api/auth/users/{id}", 1L)
+                  .header("X-User-Role", "ROLE_Admin")
+        )
+        .andExpect(status().isNotFound());
+    }
+
+    // Test getting user info -> with ShiftSupervisor (should succeed)  
+    @Test
+    @DisplayName("GET /api/auth/users/{id} with ROLE_ShiftSupervisor should succeed")
+    void getUserInfoAsShiftSupervisorShouldReturnOk() throws Exception {
+        // Given: mock the user service to return an empty optional
+        Mockito.when(userService.getUserById(anyLong())).thenReturn(Optional.empty());
+
+        // When & Then
+        mockMvc.perform(
+                get("/api/auth/users/{id}", 1L)
+                  .header("X-User-Role", "ROLE_ShiftSupervisor")
+        )
+        .andExpect(status().isNotFound());
+    }
+
+    // Test getting user info -> with Technician role
+    @Test
+    @DisplayName("GET /api/auth/users/{id} with ROLE_Technician should fail with 400")
+    void getUserInfoAsTechnicianShouldReturnBadRequest() throws Exception {
+        // Given: mock the user service to return an empty optional
+        Mockito.when(userService.getUserById(anyLong())).thenReturn(Optional.empty());
+
+        // When & Then
+        mockMvc.perform(
+                get("/api/auth/users/{id}", 1L)
+                  .header("X-User-Role", "ROLE_Technician")
+        )
+        .andExpect(status().isBadRequest());
+    }   
+
+}

--- a/planner-backend/modules/logicGate/src/main/java/com/LIT/logicGate/utilities/JwtAuthenticationFilter.java
+++ b/planner-backend/modules/logicGate/src/main/java/com/LIT/logicGate/utilities/JwtAuthenticationFilter.java
@@ -55,7 +55,7 @@ public class JwtAuthenticationFilter extends OncePerRequestFilter {
             if(requestWrap.getRequestURI().endsWith("/login") || requestWrap.getRequestURI().endsWith("/register") || requestWrap.getRequestURI().endsWith("/hello")) {
                 log.info(logHeader + "No token provided, but it's a login / register request -> proceed");
 
-                chain.doFilter(request, response);
+                chain.doFilter(requestWrap, response);
                 return;
             }
             
@@ -89,7 +89,14 @@ public class JwtAuthenticationFilter extends OncePerRequestFilter {
                     
             SecurityContextHolder.getContext().setAuthentication(authentication);
 
+            requestWrap.setAttribute("userEmail", userEmail);
+            requestWrap.setAttribute("role", role);
+
             log.info(logHeader + "User: " + userEmail + " is authenticated");
+
+            log.info(logHeader + "Request is authenticated, proceeding with request. " + requestWrap.getMethod() + " " + requestWrap.getRequestURI() + " " + requestWrap.getAttributeNames() + " " + requestWrap.getAttribute("userEmail") + " " + requestWrap.getAttribute("role"));
+
+            chain.doFilter(requestWrap, response);
 
         } else {
             // If not any of those, then invalid -> reject
@@ -98,9 +105,5 @@ public class JwtAuthenticationFilter extends OncePerRequestFilter {
             return;
         
         }
-
-        
-        log.info(logHeader + "Request is authenticated, proceeding with request");
-        chain.doFilter(request, response);
     }
 }

--- a/planner-backend/modules/logicGate/src/main/resources/application.yml
+++ b/planner-backend/modules/logicGate/src/main/resources/application.yml
@@ -16,13 +16,6 @@ jwt:
   secret: ${JWT_SECRET:secret}
 
 spring:
-  datasource:
-    platform: mariadb
-    driverClassName: ${SPRING_DATASOURCE_DRIVER_CLASS_NAME:org.mariadb.jdbc.Driver}
-    url: ${SPRING_DATASOURCE_URL:jdbc:mariadb://planner-mariadb:3306/planner}
-    username: ${SPRING_DATASOURCE_USERNAME:planner}
-    password: ${SPRING_DATASOURCE_PASSWORD:root}
-  
   jpa:
     hibernate:
       ddl-auto: update

--- a/schichtconfig/automation-scripts/run_tests.bat
+++ b/schichtconfig/automation-scripts/run_tests.bat
@@ -1,0 +1,7 @@
+@echo off
+
+setlocal
+
+cd ../../planner-backend
+
+call mvnw.cmd test

--- a/schichtconfig/automation-scripts/run_tests.sh
+++ b/schichtconfig/automation-scripts/run_tests.sh
@@ -1,0 +1,8 @@
+#!/bin/bash
+
+cd ../../planner-backend
+
+# Ensure mvnw is executable
+chmod +x ./mvnw
+
+./mvnw test


### PR DESCRIPTION
This pull request includes several changes to enhance the authorization process in the `UserController` and improve test coverage, as well as some modifications in the `LogicGateController` and related utilities. The most important changes include adding role-based authorization checks, creating new tests for the `UserController`, and modifying request handling in the `LogicGateController`.

### Authorization Enhancements:

* Added role-based authorization checks in `getUserById` and `deleteUser` methods of `UserController` to ensure only users with specific roles can perform these actions. (`planner-backend/modules/auth/src/main/java/com/LIT/auth/controller/UserController.java`)

### Testing Improvements:

* Created `UserControllerTest` to test the authorization logic for `getUserById` and `deleteUser` methods, ensuring proper access control based on user roles. (`planner-backend/modules/auth/src/test/java/com/LIT/auth/tests/controller/UserControllerTest.java`)
* Added a placeholder test class `AuthApplicationTest` for future test implementations. (`planner-backend/modules/auth/src/test/java/com/LIT/auth/AuthApplicationTest.java`)

### Request Handling Modifications:

* Enhanced `LogicGateController` to use `ContentCachingRequestWrapper` for better request logging and handling. (`planner-backend/modules/logicGate/src/main/java/com/LIT/logicGate/controller/LogicGateController.java`)
* Updated `JwtAuthenticationFilter` to wrap requests and set user attributes for better authentication handling. (`planner-backend/modules/logicGate/src/main/java/com/LIT/logicGate/utilities/JwtAuthenticationFilter.java`) [[1]](diffhunk://#diff-c6cb6ca20ddebbffef649ebb0738063c97986796c04bbf2c3f2c8e11ebaccac5L58-R58) [[2]](diffhunk://#diff-c6cb6ca20ddebbffef649ebb0738063c97986796c04bbf2c3f2c8e11ebaccac5R92-L104)

### Configuration and Script Updates:

* Removed unused datasource configuration from `application.yml`. (`planner-backend/modules/logicGate/src/main/resources/application.yml`)
* Added scripts to run tests for the backend module in both Windows (`run_tests.bat`) and Unix-based systems (`run_tests.sh`). (`schichtconfig/automation-scripts/run_tests.bat`, `schichtconfig/automation-scripts/run_tests.sh`) [[1]](diffhunk://#diff-c361529730da3fb14268faf916fcb2fce1a2bf9857ca5eed85fc6b29edc9b400R1-R7) [[2]](diffhunk://#diff-4a59fed1ded79c61e23ac6488e203bdfc7cdb8aa1d4e601452aebd21664b0ef8R1-R8)