### PR TITLE
Integration -> Employee management! Missing update existing user + body fixes for both ends

### DIFF
--- a/planner-frontend/src/Services/api.ts
+++ b/planner-frontend/src/Services/api.ts
@@ -54,7 +54,9 @@ export const testAuth = async (): Promise<void> => {
   }
 };
 
-// Login endpoint
+/*
+ * User management stuff
+*/
 export const login = async (email: string, password: string) => {
   try {
     const response = await axios.post(`${baseUrl}/api/auth/login`, {
@@ -75,7 +77,86 @@ export const login = async (email: string, password: string) => {
   }
 };
 
-// Shifts
+export const getAllUsers = async () => {
+  try {
+    const response = await axios.get(`${baseUrl}/api/auth/users`, {
+      headers: {
+        'Content-Type': 'application/json',
+        // Provide a default empty string if no token is found
+        'Authorization': localStorage.getItem('token') || ''
+      }
+    });
+
+    console.log('Users fetched successfully!', response.data);
+
+    return response.data;
+
+  } catch (error) {
+    console.error('Error getting all users', error)
+  }
+}
+
+export const getAllRoles = async () => {
+  try {
+    const response = await axios.get(`${baseUrl}/api/auth/roles`, {
+      headers: {
+        'Content-Type': 'application/json',
+        // Provide a default empty string if no token is found
+        'Authorization': localStorage.getItem('token') || ''
+      }
+    });
+
+    console.log('Roles fetched successfully!: ', response.data);
+
+    return response.data;
+
+  } catch (error) {
+    console.error('Error retrieving roles: ', error)
+  }
+}
+
+export const createUser = async (user) => {
+  try {
+    const response = await axios.post(
+      `${baseUrl}/api/auth/users`, 
+      user,
+      {
+        headers: {
+          'Content-Type': 'application/json',
+          'Authorization': localStorage.getItem('token') || ''
+        }
+      }
+    )
+
+  } catch (error) {
+    console.error('Error creating user: ', error)
+  }
+}
+
+export const updateUser = async (user) => {
+  
+}
+
+export const deleteUser = async (userId) => {
+  try {
+    const response = await axios.delete(
+      `${baseUrl}/api/auth/users/${userId}`,
+      {
+        headers: {
+          'Content-Type': 'application/json',
+          'Authorization': localStorage.getItem('token') || ''
+        }
+      }
+    )
+
+  } catch (error) {
+    console.error('Error creating user: ', error)
+  }
+}
+
+/*
+ * Shift stuff
+*/
 export const fetchShifts = async () => {
   try {
     const response = await axios.get(`${baseUrl}/api/scheduler/shifts`, {
@@ -96,7 +177,9 @@ export const fetchShifts = async () => {
   }
 }
 
-// Shift proposal
+/*
+ * Shift proposal stuff
+*/
 export const proposeShift = async (
   employeeId: number,
   proposedTitle: string,

--- a/planner-frontend/src/components/GlobalSidebar.tsx
+++ b/planner-frontend/src/components/GlobalSidebar.tsx
@@ -18,13 +18,13 @@ interface NavItem {
 }
 
 const navItems: NavItem[] = [
-  { labelKey: "employeeManagement", path: "/employee-management", roles: ["Admin", "Supervisor"] },
-  { labelKey: "shiftApproval", path: "/shift-approval", roles: ["Admin", "Supervisor"] },
-  { labelKey: "shiftSwapAdmin", path: "/shift-swap-admin", roles: ["Admin", "Supervisor"] },
-  { labelKey: "shiftManagement", path: "/shift-management", roles: ["Admin", "Supervisor"] },
-  { labelKey: "shiftAvailability", path: "/shift-availability", roles: ["Admin", "Supervisor", "Employee", "Tester", "Technician"] },
-  { labelKey: "companyShiftCalendar", path: "/shift-view", roles: ["Admin", "Supervisor", "Employee", "Tester", "Technician"] },
-  { labelKey: "shiftSwap", path: "/shift-swap", roles: ["Admin", "Supervisor", "Employee", "Tester", "Technician"] }
+  { labelKey: "employeeManagement", path: "/employee-management", roles: ["Admin", "ShiftSupervisor"] },
+  { labelKey: "shiftApproval", path: "/shift-approval", roles: ["Admin", "ShiftSupervisor"] },
+  { labelKey: "shiftSwapAdmin", path: "/shift-swap-admin", roles: ["Admin", "ShiftSupervisor"] },
+  { labelKey: "shiftManagement", path: "/shift-management", roles: ["Admin", "ShiftSupervisor"] },
+  { labelKey: "shiftAvailability", path: "/shift-availability", roles: ["Admin", "ShiftSupervisor", "Employee", "Tester", "Technician"] },
+  { labelKey: "companyShiftCalendar", path: "/shift-view", roles: ["Admin", "ShiftSupervisor", "Employee", "Tester", "Technician"] },
+  { labelKey: "shiftSwap", path: "/shift-swap", roles: ["Admin", "ShiftSupervisor", "Employee", "Tester", "Technician"] }
 ];
 
 const GlobalSidebar: React.FC<GlobalSidebarProps> = ({ open, onClose }) => {

--- a/planner-frontend/src/pages/admin/EmployeeManagement.css
+++ b/planner-frontend/src/pages/admin/EmployeeManagement.css
@@ -133,6 +133,8 @@
   border-radius: 4px;
   cursor: pointer;
   transition: background 0.3s ease;
+  text-align: center;
+
 }
 
 .employee-table button:first-of-type {

--- a/planner-frontend/src/pages/admin/EmployeeManagement.tsx
+++ b/planner-frontend/src/pages/admin/EmployeeManagement.tsx
@@ -96,29 +96,35 @@ const EmployeeManagement: React.FC<EmployeeManagementProps> = () => {
 
   // Handle form submission for adding/updating an employee
   const onSubmit = async (data: any) => {
-    try {
-      const selectedRole = roles.find((role) => role.name === data.role);
-      
-      if (!selectedRole) {
-        console.error("Invalid role selected.");
-        return;
+
+    if(editingEmployeeId == null){
+      try {
+        const selectedRole = roles.find((role) => role.name === data.role);
+        
+        if (!selectedRole) {
+          console.error("Invalid role selected.");
+          return;
+        }
+    
+        const newUser = {
+          email: data.email,
+          username: data.name,
+          password: "password_test", // Default password (consider making this configurable)
+          googleId: "",
+          roles: [{ id: selectedRole.id, name: selectedRole.name }]
+        };
+    
+        await createUser(newUser);
+        
+        reset(); // Clear the form after submission
+        fetchEmployees(); // Refresh employee list after adding a new user
+    
+      } catch (error) {
+        console.error("Error creating user:", error);
       }
-  
-      const newUser = {
-        email: data.email,
-        username: data.name,
-        password: "password_test", // Default password (consider making this configurable)
-        googleId: "",
-        roles: [{ id: selectedRole.id, name: selectedRole.name }]
-      };
-  
-      await createUser(newUser);
-      
-      reset(); // Clear the form after submission
-      fetchEmployees(); // Refresh employee list after adding a new user
-  
-    } catch (error) {
-      console.error("Error creating user:", error);
+
+    } else {
+      window.alert("User update coming soon!")
     }
   };
 

--- a/planner-frontend/src/pages/admin/EmployeeManagement.tsx
+++ b/planner-frontend/src/pages/admin/EmployeeManagement.tsx
@@ -1,9 +1,12 @@
 // src/pages/admin/EmployeeManagement.tsx
-import React, { useState } from "react";
+import React, { useEffect, useState } from "react";
 import { useForm } from "react-hook-form";
 import { useAuth } from "../../AuthContext.tsx"; // Adjust the path as needed
 import { useTranslation } from "react-i18next";
 import "./EmployeeManagement.css";
+
+// API calls:
+import { getAllUsers, getAllRoles, createUser, updateUser, deleteUser } from "../../Services/api.ts";
 
 // Define an interface for employee data
 interface Employee {
@@ -29,9 +32,17 @@ const roleTranslationMap: { [key: string]: string } = {
   // Add any other roles as needed
 };
 
-const EmployeeManagement: React.FC<EmployeeManagementProps> = ({ allowDelete = false }) => {
+const EmployeeManagement: React.FC<EmployeeManagementProps> = () => {
   const { t } = useTranslation();
   const { user } = useAuth();
+
+  useEffect(() => {
+    if (user && user.role === "Admin") {
+      setAllowDelete(true);
+    } else {
+      setAllowDelete(false);
+    }
+  }, [user]);
 
   // Set up React Hook Form
   const {
@@ -43,53 +54,72 @@ const EmployeeManagement: React.FC<EmployeeManagementProps> = ({ allowDelete = f
   } = useForm();
 
   // Pre-populated list of employees
-  const [employees, setEmployees] = useState<Employee[]>([
-    {
-      id: 1,
-      name: "Justus Magdy",
-      address: "123 Main St, Anytown",
-      phone: "555-123-4567",
-      email: "justmag@example.com",
-      role: "shift_supervisor", // Raw role string
-      absences: 2,
-    },
-    {
-      id: 2,
-      name: "Hany Ali",
-      address: "456 Oak Ave, Othertown",
-      phone: "555-987-6543",
-      email: "hanyali@example.com",
-      role: "technician",
+  const [allowDelete, setAllowDelete] = useState(false);
+  const [employees, setEmployees] = useState<Employee[]>([]);
+  const [roles, setRoles] = useState<{ id: number; name: string }[]>([]);
+
+  
+  const fetchEmployees = async () => {
+    const employees = await getAllUsers();
+    
+    const formattedEmployees = employees.map((emp: any) => ({
+      id: emp.id,
+      name: emp.username,
+      address: "N/A",
+      phone: "N/A",
+      email: emp.email,
+      role: emp.roles.length > 0 ? emp.roles[0].name.replace("-", " ") : "unknown",
       absences: 0,
-    },
-  ]);
+    }));
+
+    setEmployees(formattedEmployees);
+  };
+
+  // Fetch employees on component mount
+  useEffect(() => {
+
+    fetchEmployees();
+  }, []);
+
+  useEffect(() => {
+    const fetchRoles = async () => {
+      const roles = await getAllRoles();
+
+      setRoles(roles);
+    }
+
+    fetchRoles();
+  }, []);
 
   // Track which employee is being edited; null means we're adding a new employee
   const [editingEmployeeId, setEditingEmployeeId] = useState<number | null>(null);
 
   // Handle form submission for adding/updating an employee
-  const onSubmit = (data: any) => {
-    // Convert string to number for absences
-    const employeeData: Employee = {
-      ...data,
-      absences: Number(data.absences),
-      // If editing, reuse the existing ID; otherwise create a new one
-      id: editingEmployeeId ? editingEmployeeId : Date.now(),
-    };
-
-    if (editingEmployeeId) {
-      // Update existing employee
-      setEmployees((prev) =>
-        prev.map((emp) =>
-          emp.id === editingEmployeeId ? employeeData : emp
-        )
-      );
-      setEditingEmployeeId(null);
-    } else {
-      // Add new employee
-      setEmployees((prev) => [...prev, employeeData]);
+  const onSubmit = async (data: any) => {
+    try {
+      const selectedRole = roles.find((role) => role.name === data.role);
+      
+      if (!selectedRole) {
+        console.error("Invalid role selected.");
+        return;
+      }
+  
+      const newUser = {
+        email: data.email,
+        username: data.name,
+        password: "password_test", // Default password (consider making this configurable)
+        googleId: "",
+        roles: [{ id: selectedRole.id, name: selectedRole.name }]
+      };
+  
+      await createUser(newUser);
+      
+      reset(); // Clear the form after submission
+      fetchEmployees(); // Refresh employee list after adding a new user
+  
+    } catch (error) {
+      console.error("Error creating user:", error);
     }
-    reset();
   };
 
   // Pre-fill the form with an employee's data for editing
@@ -104,9 +134,12 @@ const EmployeeManagement: React.FC<EmployeeManagementProps> = ({ allowDelete = f
   };
 
   // Delete an employee (only if allowed and user is Admin)
-  const deleteEmployee = (id: number) => {
+  const deleteEmployee = async (id: number) => {
     if (window.confirm(t("confirmDelete") || "Are you sure you want to delete this employee?")) {
-      setEmployees((prev) => prev.filter((emp) => emp.id !== id));
+      
+      await deleteUser(id)
+
+      fetchEmployees();
     }
   };
 
@@ -180,16 +213,15 @@ const EmployeeManagement: React.FC<EmployeeManagementProps> = ({ allowDelete = f
 
         <div className="form-row">
           <label>{t("role") || "Role"}:</label>
-          <input
-            {...register("role", {
-              required: t("roleRequired") || "Role is required",
-            })}
-            placeholder={
-              t("rolePlaceholder") ||
-              "Role (e.g., shift supervisor, technician, tester, incident-manager)"
-            }
-          />
-          {errors.role && <p className="error">{errors.role.message}</p>}
+          <select {...register("role", { required: t("roleRequired") || "Role is required" })}>
+            <option value="">{t("Select Role") || "Select a Role"}</option>
+              {roles.map((role) => (
+                <option key={role.id} value={role.name}>
+                  {t(roleTranslationMap[role.name.replace("-", " ")] || role.name.replace("-", " "))}
+                </option>
+              ))}
+        </select>
+        {errors.role && <p className="error">{errors.role.message}</p>}
         </div>
 
         <div className="form-row">
@@ -246,12 +278,12 @@ const EmployeeManagement: React.FC<EmployeeManagementProps> = ({ allowDelete = f
               {/* Map the raw role to a translated label */}
               <td>{getRoleLabel(emp.role)}</td>
               <td>{emp.absences}</td>
-              <td>
+              <td align="center">
                 <button onClick={() => editEmployee(emp)}>
                   {t("edit") || "Edit"}
                 </button>
                 {/* Only show delete if allowed and user is an Administrator */}
-                {allowDelete && user?.role === "Administrator" && (
+                {allowDelete && (
                   <button onClick={() => deleteEmployee(emp.id)}>
                     {t("delete") || "Delete"}
                   </button>

--- a/planner-frontend/src/pages/admin/ShiftApprovalCalendar.tsx
+++ b/planner-frontend/src/pages/admin/ShiftApprovalCalendar.tsx
@@ -107,10 +107,6 @@ const ShiftApprovalCalendar = () => {
 
   };
 
-  const handleAlternative = (id) => {
-    alert("Propose alternative shift time.\nUpdate enabling this action comming soon.");
-  };
-
   const calendarEvents = shifts.map((shift) => ({
     ...shift,
     title: `${shift.title} - ${shift.employee}`
@@ -219,9 +215,6 @@ const ShiftApprovalCalendar = () => {
                     </button>
                     <button onClick={() => handleReject(req.id)} className="approve-btn">
                       {t("reject") || "Reject"}
-                    </button>
-                    <button onClick={() => handleAlternative(req.id)} className="approve-btn">
-                      {t("proposeAlternative") || "Propose Alternative"}
                     </button>
                   </td>
                 </tr>


### PR DESCRIPTION
### Main Highlights
- Fixed sidebar content access for shift supervisor
- Finished shift proposal approval / rejection
- API additions: getAllUsers, getAllRoles, createUser & deleteUser
- Employee management (as admin) can now: create & delete users. Shift supervisor can only create as requested
! - Missing existing user update, finishing soon. Got to fix some request bodies.

### Copilot's summary
This pull request introduces several new API endpoints for user management and updates the employee management interface to integrate with these endpoints. Additionally, it includes some UI improvements and role updates for the navigation items.

### API Endpoints for User Management:
* Added new functions `getAllUsers`, `getAllRoles`, `createUser`, `updateUser`, and `deleteUser` to `planner-frontend/src/Services/api.ts` for handling user-related operations.

### Employee Management Interface:
* Integrated the new API endpoints into `EmployeeManagement.tsx`, allowing the fetching, creation, and deletion of users from the backend. [[1]](diffhunk://#diff-b70a39df25575aef59e1f2d4c666f1359e62932be494a57453e508dd9c92212cL2-R10) [[2]](diffhunk://#diff-b70a39df25575aef59e1f2d4c666f1359e62932be494a57453e508dd9c92212cL46-L92) [[3]](diffhunk://#diff-b70a39df25575aef59e1f2d4c666f1359e62932be494a57453e508dd9c92212cL107-R148)
* Replaced the hardcoded employee list with data fetched from the backend.
* Updated the role selection to use a dropdown populated with roles fetched from the backend.

### UI Improvements:
* Centered text in buttons within `EmployeeManagement.css` to enhance the UI.
* Aligned the action buttons in the employee table to the center for better visual consistency.

### Navigation Role Updates:
* Updated navigation items in `GlobalSidebar.tsx` to reflect the new role "ShiftSupervisor".

### Cleanup:
* Removed the unused `handleAlternative` function and related button in `ShiftApprovalCalendar.tsx`. [[1]](diffhunk://#diff-8930ce9e1963aacbbc5febc28cfda52e0d6af80f5e058d531bd09518289fd0f2L110-L113) [[2]](diffhunk://#diff-8930ce9e1963aacbbc5febc28cfda52e0d6af80f5e058d531bd09518289fd0f2L223-L225)