### PR TITLE
Integration -> Ensured consistency for CompanyShift, ProposalApproval & ShiftMngmt Calendars

### DIFF
--- a/planner-backend/modules/auth/src/main/java/com/LIT/auth/service/AuthenticationService.java
+++ b/planner-backend/modules/auth/src/main/java/com/LIT/auth/service/AuthenticationService.java
@@ -170,6 +170,7 @@ public class AuthenticationService {
         //get the first one (this is assuming each user has AT LEAST one)
         String role = user.getRoles().iterator().next().getName();
         String permissions = String.join(",", user.getRoles().iterator().next().getPermissions());
+        String username = user.getUsername();
 
         log.info(logHeader + "login: User found. Generating token...");
 
@@ -181,6 +182,7 @@ public class AuthenticationService {
         toReturn.put("email", user.getEmail());
         toReturn.put("role", role);
         toReturn.put("userId", user.getId().toString());
+        toReturn.put("username", username);
         toReturn.put("permissions", permissions);
 
         log.info(logHeader + "User " + user.getEmail() + " logged in successfully. Returnig token.");

--- a/planner-frontend/src/Services/api.ts
+++ b/planner-frontend/src/Services/api.ts
@@ -369,7 +369,7 @@ export const supervisorCreateShift = async (shift) => {
   console.log('Creating shift:', shift);
   
   const shiftToCreate = {
-    shiftOwnerId: shift.employeeId || null,
+    shiftOwnerId: shift.shiftOwnerId || null,
     title: shift.title,
     shiftOwnerName: shift.shiftOwner || "",
     shiftOwnerRole: shift.role, 

--- a/planner-frontend/src/Services/api.ts
+++ b/planner-frontend/src/Services/api.ts
@@ -75,7 +75,7 @@ export const login = async (email: string, password: string) => {
 
     console.log('Logged in successfully! user:', data.email, 'role:', data.role, 'token:', data.token, 'userId:', data.userId, 'permissions:', permissionsArray);
 
-    return { email: data.email, role: data.role, token: data.token, userId: data.userId, permissions: permissionsArray };
+    return { email: data.email, role: data.role, token: data.token, userId: data.userId, permissions: permissionsArray, username: data.username };
 
   } catch (error) {
     console.error('Error logging in', error);

--- a/planner-frontend/src/components/GlobalSidebar.tsx
+++ b/planner-frontend/src/components/GlobalSidebar.tsx
@@ -43,6 +43,9 @@ const GlobalSidebar: React.FC<GlobalSidebarProps> = ({ open, onClose }) => {
     localStorage.removeItem("token");
     localStorage.removeItem("lang");
     localStorage.removeItem("userId");
+    localStorage.removeItem("permissions");
+    localStorage.removeItem("role");
+
     navigate("/login");
     onClose();
   };

--- a/planner-frontend/src/pages/admin/ShiftApprovalCalendar.tsx
+++ b/planner-frontend/src/pages/admin/ShiftApprovalCalendar.tsx
@@ -154,7 +154,7 @@ const ShiftApprovalCalendar: React.FC = () => {
 
   const calendarEvents = shifts.map((shift) => ({
     id: shift.id,
-    title: `${shift.title} (${shift.shiftOwner})`,
+    title: `${shift.title}`,
     start: shift.start,
     end: shift.end,
     role: shift.role,

--- a/planner-frontend/src/pages/admin/ShiftManagement.tsx
+++ b/planner-frontend/src/pages/admin/ShiftManagement.tsx
@@ -98,7 +98,7 @@ const ShiftManagement = ({ currentUser = { id: 1 } }) => {
 
   const calendarEvents = shifts.map((shift: Shift) => ({
     id: shift.id,
-    title: `${shift.title} (${shift.shiftOwner})`,
+    title: `${shift.title}`,
     shiftOwner: shift.shiftOwner,
     start: shift.start,
     end: shift.end,

--- a/planner-frontend/src/pages/admin/ShiftManagement.tsx
+++ b/planner-frontend/src/pages/admin/ShiftManagement.tsx
@@ -19,7 +19,7 @@ const ShiftManagement = ({ currentUser = { id: 1 } }) => {
   interface Shift {
     id: number;
     title: string;
-    employeeId: number | null;
+    shiftOwnerId: number | null;
     shiftOwner: string;
     role: string;
     start: Date;
@@ -30,7 +30,7 @@ const ShiftManagement = ({ currentUser = { id: 1 } }) => {
     return shifts.map((shift) => ({
       id: shift.id,
       title: shift.title || t("unnamedShift"),
-      employeeId: shift.employeeId || null,
+      shiftOwnerId: shift.shiftOwnerId || null,
       shiftOwner: shift.shiftOwnerName || t("unassigned"),
       role: shift.shiftOwnerRole || t("unassigned"),
       start: new Date(shift.startTime),
@@ -87,7 +87,7 @@ const ShiftManagement = ({ currentUser = { id: 1 } }) => {
   const [newShift, setNewShift] = useState<Shift>({
     id: 0,
     title: "",
-    employeeId: null,
+    shiftOwnerId: null,
     shiftOwner: "",
     role: "",
     start: new Date(),
@@ -103,7 +103,7 @@ const ShiftManagement = ({ currentUser = { id: 1 } }) => {
     start: shift.start,
     end: shift.end,
     role: shift.role,
-    employeeId: shift.employeeId
+    shiftOwnerId: shift.shiftOwnerId
   }));
 
   // Dynamic event styling
@@ -174,7 +174,7 @@ const ShiftManagement = ({ currentUser = { id: 1 } }) => {
           start: start,
           end: end,
           role: newShift.role,
-          employeeId: newShift.employeeId || null,
+          shiftOwnerId: newShift.shiftOwnerId || null,
           shiftOwner: newShift.shiftOwner,
         });
 
@@ -187,12 +187,12 @@ const ShiftManagement = ({ currentUser = { id: 1 } }) => {
           start: start,
           end: end,
           role: newShift.role,
-          employeeId: newShift.employeeId || null,
+          shiftOwnerId: newShift.shiftOwnerId || null,
           shiftOwner: newShift.shiftOwner,
         });
       }
 
-      setNewShift({ id: 0, shiftOwner: "", title: "", start: new Date(), end: new Date(), role: "" , employeeId: null});
+      setNewShift({ id: 0, shiftOwner: "", title: "", start: new Date(), end: new Date(), role: "" , shiftOwnerId: null});
       await loadShifts();
     } catch (error) {
       console.error("Error adding/updating shift:", error);
@@ -207,7 +207,7 @@ const ShiftManagement = ({ currentUser = { id: 1 } }) => {
       start: moment(shift.start).format("YYYY-MM-DDTHH:mm"),
       end: moment(shift.end).format("YYYY-MM-DDTHH:mm"),
       role: shift.role,
-      employeeId: shift.employeeId ,
+      shiftOwnerId: shift.shiftOwnerId ,
       shiftOwner: shift.shiftOwner,
     });
 
@@ -249,14 +249,14 @@ const ShiftManagement = ({ currentUser = { id: 1 } }) => {
     if (selectedEmployee) {
       setNewShift({
         ...newShift,
-        employeeId: selectedEmployee.id,
+        shiftOwnerId: selectedEmployee.id,
         shiftOwner: selectedEmployee.name,
         role: selectedEmployee.role,
       });
     } else {
       setNewShift({
         ...newShift,
-        employeeId: null,
+        shiftOwnerId: null,
         shiftOwner: "", // Reset if no employee selected
         role: "Unassigned",
       });
@@ -281,7 +281,7 @@ const ShiftManagement = ({ currentUser = { id: 1 } }) => {
               <>
               <label>{t("selectEmployee") || "Select Employee"}:</label>
               <select
-                value={newShift.employeeId || ""} // Ensure it selects the correct employee ID
+                value={newShift.shiftOwnerId || ""} // Ensure it selects the correct employee ID
                 onChange={handleEmployeeChange}
                 required
               >
@@ -358,7 +358,7 @@ const ShiftManagement = ({ currentUser = { id: 1 } }) => {
                       end: new Date(),
                       shiftOwner: "",
                       role : "",
-                      employeeId: null,
+                      shiftOwnerId: null,
                     });
                   }}
                 >
@@ -394,6 +394,7 @@ const ShiftManagement = ({ currentUser = { id: 1 } }) => {
         <table>
           <thead>
             <tr>
+              <th>{t("employeeId") || "Employee Id"}</th>
               <th>{t("employeeName") || "Employee Name"}</th>
               <th>{t("date") || "Date"}</th>
               <th>{t("time") || "Time"}</th>
@@ -404,6 +405,7 @@ const ShiftManagement = ({ currentUser = { id: 1 } }) => {
           <tbody>
             {shifts.map((shift) => (
               <tr key={shift.id}>
+                <td>{shift.shiftOwnerId || t("unassigned") || "Unassigned"}</td>
                 <td>
                   {shift.shiftOwner || t("unassigned") || "Unassigned"}
                 </td>

--- a/planner-frontend/src/pages/employee/CompanyShiftCalendar.tsx
+++ b/planner-frontend/src/pages/employee/CompanyShiftCalendar.tsx
@@ -96,7 +96,7 @@ const CompanyShiftCalendar: React.FC = () => {
 
     return {
       ...shift,
-      title: `${shift.title} (${displayedOwner})`,
+      title: `${shift.title}`,
     };
   });
 

--- a/planner-frontend/src/pages/employee/ShiftAvailability.tsx
+++ b/planner-frontend/src/pages/employee/ShiftAvailability.tsx
@@ -166,13 +166,14 @@ const ShiftAvailability: React.FC = () => {
 
     const employeeData = JSON.parse(employee);
     const employeeId = employeeData.userId;
+    const empName = employeeData.username;
     const role = employeeData.role;
     if (!employeeId) {
       showNotification(t("employeeIdNotFound") || "Error: Employee ID not found.", "error");
       return;
     }
-
-    const proposedTitle = `Shift for Employee ${employeeId} (${role})`;
+    
+    const proposedTitle = `Shift for '${empName}' (${role})`;
     const status = "PROPOSED";
 
     let hasAtLeastOneShift = false;
@@ -252,7 +253,16 @@ const ShiftAvailability: React.FC = () => {
       const oldProposal = myProposals[editIndex];
 
     // You’ll need the employee ID:
-    const empId = localStorage.getItem("userId");
+    const loggedemployee = localStorage.getItem("user");
+    if (!loggedemployee) {
+      showNotification("Error: Employee not found.", "error");
+      return;
+    }
+
+    const employeeData = JSON.parse(loggedemployee);
+    const empName = employeeData.username;
+    const empId = employeeData.userId;
+    const role = employeeData.role;
     
     if (!empId) {
       showNotification("Error: Employee not found.", "error");
@@ -269,7 +279,8 @@ const ShiftAvailability: React.FC = () => {
 
     const proposedStartTime = startDate.toISOString();
     const proposedEndTime = endDate.toISOString();
-    const proposedTitle = `Shift for Employee ${empId}`;
+    
+    const proposedTitle = `Shift for '${empName}' (${role})`;
     const status = "PROPOSED";
 
     // Construct the payload the server expects

--- a/planner-frontend/src/pages/general/Login.tsx
+++ b/planner-frontend/src/pages/general/Login.tsx
@@ -9,6 +9,7 @@ import "./Login.css";
 
 interface AuthUser {
   userId: number;
+  username: string;
   email: string;
   role: string;
   permissions: string;
@@ -40,6 +41,7 @@ const Login: React.FC = () => {
         const retEmail = loginInfo.email;
         const token = loginInfo.token;
         const userId = loginInfo.userId;
+        const username = loginInfo.username;
         const permissions = Array.isArray(loginInfo.permissions) ? loginInfo.permissions : [];
         
         console.log('Email:', retEmail);
@@ -47,8 +49,9 @@ const Login: React.FC = () => {
         console.log('Id:', userId);
         console.log("Token: '" +  token + "'");
         console.log("Permissions: '" +  permissions + "'");
+        console.log("Username: '" +  username + "'");
 
-        setUser({ email: retEmail, role: retRole, userId: userId, permissions: permissions });
+        setUser({ email: retEmail, role: retRole, userId: userId, permissions: permissions, username: username });
 
         // Instead of navigating based on role, always redirect to the Company Shift Calendar page.
         navigate("/shift-view");


### PR DESCRIPTION
This pull request includes several changes to the backend and frontend components of the planner application, primarily focusing on improving user information handling and shift management.

### Backend Improvements:
* [`AuthenticationService.java`](diffhunk://#diff-2142179ba3992c1d6024705f312286cf76460a3e1a73e43087aa4f3919137700R173): Added `username` to the login response to include the username in the returned data. [[1]](diffhunk://#diff-2142179ba3992c1d6024705f312286cf76460a3e1a73e43087aa4f3919137700R173) [[2]](diffhunk://#diff-2142179ba3992c1d6024705f312286cf76460a3e1a73e43087aa4f3919137700R185)

### Frontend Enhancements:
* [`api.ts`](diffhunk://#diff-7193e052deef018746a9a554bdba3b892bd165ac8edd67d152c36541814e4f11L78-R78): Updated the login function to return the `username` and modified the `supervisorCreateShift` function to use `shiftOwnerId` instead of `employeeId`. [[1]](diffhunk://#diff-7193e052deef018746a9a554bdba3b892bd165ac8edd67d152c36541814e4f11L78-R78) [[2]](diffhunk://#diff-7193e052deef018746a9a554bdba3b892bd165ac8edd67d152c36541814e4f11L372-R372)
* [`GlobalSidebar.tsx`](diffhunk://#diff-42787c56c0f93b6d64353881c8b072d537a136aa1980f4abae0ff86277a3974dR46-R48): Added removal of `permissions` and `role` from localStorage upon logout.

### Shift Management and Approval:
* [`ShiftApprovalCalendar.tsx`](diffhunk://#diff-8930ce9e1963aacbbc5febc28cfda52e0d6af80f5e058d531bd09518289fd0f2L8-R104): Refactored the component to use TypeScript interfaces for `Shift` and `ProposalShift`, added mappers for API responses, and improved the loading and handling of shifts and proposals. [[1]](diffhunk://#diff-8930ce9e1963aacbbc5febc28cfda52e0d6af80f5e058d531bd09518289fd0f2L8-R104) [[2]](diffhunk://#diff-8930ce9e1963aacbbc5febc28cfda52e0d6af80f5e058d531bd09518289fd0f2L58-R207) [[3]](diffhunk://#diff-8930ce9e1963aacbbc5febc28cfda52e0d6af80f5e058d531bd09518289fd0f2R228-R229) [[4]](diffhunk://#diff-8930ce9e1963aacbbc5febc28cfda52e0d6af80f5e058d531bd09518289fd0f2R238-R240) [[5]](diffhunk://#diff-8930ce9e1963aacbbc5febc28cfda52e0d6af80f5e058d531bd09518289fd0f2L205-R252) [[6]](diffhunk://#diff-8930ce9e1963aacbbc5febc28cfda52e0d6af80f5e058d531bd09518289fd0f2L224-R270)
* [`ShiftManagement.tsx`](diffhunk://#diff-866f3b280ca15e795473e6b9fd1b7bc4a94b70e8bd1f2e8f39e98cc7befb02f5L22-R22): Updated the component to use `shiftOwnerId` instead of `employeeId` and added display of `shiftOwnerId` in the shift management table. [[1]](diffhunk://#diff-866f3b280ca15e795473e6b9fd1b7bc4a94b70e8bd1f2e8f39e98cc7befb02f5L22-R22) [[2]](diffhunk://#diff-866f3b280ca15e795473e6b9fd1b7bc4a94b70e8bd1f2e8f39e98cc7befb02f5L33-R33) [[3]](diffhunk://#diff-866f3b280ca15e795473e6b9fd1b7bc4a94b70e8bd1f2e8f39e98cc7befb02f5L90-R90) [[4]](diffhunk://#diff-866f3b280ca15e795473e6b9fd1b7bc4a94b70e8bd1f2e8f39e98cc7befb02f5L101-R106) [[5]](diffhunk://#diff-866f3b280ca15e795473e6b9fd1b7bc4a94b70e8bd1f2e8f39e98cc7befb02f5L177-R177) [[6]](diffhunk://#diff-866f3b280ca15e795473e6b9fd1b7bc4a94b70e8bd1f2e8f39e98cc7befb02f5L190-R195) [[7]](diffhunk://#diff-866f3b280ca15e795473e6b9fd1b7bc4a94b70e8bd1f2e8f39e98cc7befb02f5L210-R210) [[8]](diffhunk://#diff-866f3b280ca15e795473e6b9fd1b7bc4a94b70e8bd1f2e8f39e98cc7befb02f5L252-R259) [[9]](diffhunk://#diff-866f3b280ca15e795473e6b9fd1b7bc4a94b70e8bd1f2e8f39e98cc7befb02f5L284-R284) [[10]](diffhunk://#diff-866f3b280ca15e795473e6b9fd1b7bc4a94b70e8bd1f2e8f39e98cc7befb02f5L361-R361) [[11]](diffhunk://#diff-866f3b280ca15e795473e6b9fd1b7bc4a94b70e8bd1f2e8f39e98cc7befb02f5R397) [[12]](diffhunk://#diff-866f3b280ca15e795473e6b9fd1b7bc4a94b70e8bd1f2e8f39e98cc7befb02f5R408)