### PR TITLE
Integration -> Transition from backend role based access to permission based

### DIFF
--- a/planner-backend/modules/auth/src/main/java/com/LIT/auth/service/AuthenticationService.java
+++ b/planner-backend/modules/auth/src/main/java/com/LIT/auth/service/AuthenticationService.java
@@ -6,13 +6,11 @@ import java.util.Map;
 import java.util.Optional;
 import java.util.Set;
 
-import org.checkerframework.checker.units.qual.m;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.security.crypto.password.PasswordEncoder;
 import org.springframework.stereotype.Service;
 
 import com.LIT.auth.exception.InvalidCredentialsException;
-import com.LIT.auth.exception.UserAlreadyExistsException;
 import com.LIT.auth.model.dto.Req.LoginRequest;
 import com.LIT.auth.model.dto.Req.RegisterRequest;
 import com.LIT.auth.model.entity.Role;
@@ -175,7 +173,7 @@ public class AuthenticationService {
         log.info(logHeader + "login: User found. Generating token...");
 
         // Generate token
-        String token = "Bearer " + jwtTokenUtil.generateToken(user.getEmail(), role, user.getId(), user.getUsername());
+        String token = "Bearer " + jwtTokenUtil.generateToken(user.getEmail(), role, user.getId(), user.getUsername(), permissions);
 
         Map<String, String> toReturn = new HashMap<>();
         toReturn.put("token", token);
@@ -238,7 +236,7 @@ public class AuthenticationService {
         log.info(logHeader + "login: newUser found. Generating token...");
 
         // Generate token
-        String token = "Bearer " + jwtTokenUtil.generateToken(newUser.getEmail(), role, newUser.getId(), newUser.getUsername());
+        String token = "Bearer " + jwtTokenUtil.generateToken(newUser.getEmail(), role, newUser.getId(), newUser.getUsername(), permissions);
 
         Map<String, String> toReturn = new HashMap<>();
         toReturn.put("token", token);

--- a/planner-backend/modules/auth/src/main/java/com/LIT/auth/utilities/JwtTokenUtil.java
+++ b/planner-backend/modules/auth/src/main/java/com/LIT/auth/utilities/JwtTokenUtil.java
@@ -21,7 +21,7 @@ public class JwtTokenUtil {
 
     private static final long EXPIRATION_TIME = 3600000; // 1 hour
 
-    public String generateToken(String email, String role, Long userId, String username) {
+    public String generateToken(String email, String role, Long userId, String username, String permissions) {
         log.info(logHeader + "generateToken: Generating token for user: " + email);        
         return JWT.create()
                 .withIssuer("LIT - auth0")
@@ -30,6 +30,7 @@ public class JwtTokenUtil {
                 .withClaim("role", role)
                 .withClaim("userName", username)
                 .withClaim("userId", userId)
+                .withClaim("permissions", permissions)
                 .withIssuedAt(new Date(System.currentTimeMillis()))
                 .withExpiresAt(new Date(System.currentTimeMillis() + EXPIRATION_TIME))
                 .sign(Algorithm.HMAC256(secret));
@@ -53,6 +54,11 @@ public class JwtTokenUtil {
     public String extractUsername(String token) {
         log.info(logHeader + "extractUsername: Extracting username from token");
         return JWT.decode(token).getClaim("userName").asString();
+    }
+
+    public String extractPermissions(String token) {
+        log.info(logHeader + "extractPermissions: Extracting permissions from token");
+        return JWT.decode(token).getClaim("permissions").asString();
     }
 
     public boolean validateToken(String token) {

--- a/planner-backend/modules/auth/src/test/java/com/LIT/auth/tests/controller/UserControllerTest.java
+++ b/planner-backend/modules/auth/src/test/java/com/LIT/auth/tests/controller/UserControllerTest.java
@@ -40,7 +40,7 @@ class UserControllerTest {
 
         mockMvc.perform(
                 delete("/api/auth/users/{id}", 1L)
-                  .header("X-User-Role", "ROLE_Admin")
+                  .header("X-User-Permissions", "SWAP_APPROVAL,SWAP_PROPOSAL,CALENDAR_VIEW,ROLE_MANAGEMENT,SHIFT_PROPOSAL,EMPLOYEE_MANAGEMENT,PROPOSAL_APPROVAL,SHIFT_MANAGEMENT,EMPLOYEE_DELETE")
         )
         .andExpect(status().isNoContent());
     }
@@ -54,9 +54,9 @@ class UserControllerTest {
 
         mockMvc.perform(
                 delete("/api/auth/users/{id}", 1L)
-                  .header("X-User-Role", "ROLE_Shift-Supervisor")
+                  .header("X-User-Permissions", "SWAP_APPROVAL,SWAP_PROPOSAL,CALENDAR_VIEW,ROLE_MANAGEMENT,SHIFT_PROPOSAL,EMPLOYEE_MANAGEMENT,PROPOSAL_APPROVAL,SHIFT_MANAGEMENT")
         )
-        .andExpect(status().isBadRequest());
+        .andExpect(status().isForbidden());
     }
 
     /*
@@ -71,7 +71,7 @@ class UserControllerTest {
 
         mockMvc.perform(
                 get("/api/auth/users/{id}", 1L)
-                  .header("X-User-Role", "ROLE_Admin")
+                  .header("X-User-Permissions", "SWAP_APPROVAL,SWAP_PROPOSAL,CALENDAR_VIEW,ROLE_MANAGEMENT,SHIFT_PROPOSAL,EMPLOYEE_MANAGEMENT,PROPOSAL_APPROVAL,SHIFT_MANAGEMENT,EMPLOYEE_DELETE")
         )
         .andExpect(status().isNotFound());
     }
@@ -85,7 +85,7 @@ class UserControllerTest {
 
         mockMvc.perform(
                 get("/api/auth/users/{id}", 1L)
-                  .header("X-User-Role", "ROLE_Shift-Supervisor")
+                  .header("X-User-Permissions", "SWAP_APPROVAL,SWAP_PROPOSAL,CALENDAR_VIEW,ROLE_MANAGEMENT,SHIFT_PROPOSAL,EMPLOYEE_MANAGEMENT,PROPOSAL_APPROVAL,SHIFT_MANAGEMENT")
         )
         .andExpect(status().isNotFound());
     }
@@ -100,9 +100,9 @@ class UserControllerTest {
 
         mockMvc.perform(
                 get("/api/auth/users/{id}", 1L)
-                  .header("X-User-Role", "ROLE_Technician")
+                  .header("X-User-Permissions", "SWAP_PROPOSAL,CALENDAR_VIEW,SHIFT_PROPOSAL")
         )
-        .andExpect(status().isBadRequest());
+        .andExpect(status().isForbidden());
     }   
 
 }

--- a/planner-backend/modules/auth/src/test/java/com/LIT/auth/tests/unittests/RoleTest.java
+++ b/planner-backend/modules/auth/src/test/java/com/LIT/auth/tests/unittests/RoleTest.java
@@ -1,25 +1,118 @@
 package com.LIT.auth.tests.unittests;
 
-import static org.junit.jupiter.api.Assertions.assertEquals; // Correct static import for assertions
-import org.junit.jupiter.api.Test; // Import for the @Test annotation
+import java.util.List;
+import java.util.Optional;
+import java.util.Set;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import static org.mockito.ArgumentMatchers.any;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import static org.mockito.Mockito.doNothing;
+import static org.mockito.Mockito.times;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+import org.mockito.junit.jupiter.MockitoExtension;
 
 import com.LIT.auth.model.entity.Role;
+import com.LIT.auth.model.repository.RoleRepository;
+import com.LIT.auth.service.RoleService;
 
+@ExtendWith(MockitoExtension.class)
 public class RoleTest {
 
-    //Verifies that object Role is definied
-    @Test
-    void testRoleCreation() {
-        Role role = new Role(1L, "ADMIN", null);
-        assertEquals(1L, role.getId());  // Direct comparison with primitive long
-        assertEquals("ADMIN", role.getName());
+    @Mock
+    private RoleRepository roleRepository;
+
+    @InjectMocks
+    private RoleService roleService;
+
+    private Role role;
+
+    @BeforeEach
+    void setUp() {
+        role = Role.builder().id(1L).name("ADMIN").permissions(Set.of("ROLE_MANAGEMENT", "EMPLOYEE_MANAGEMENT")).build();
     }
 
-    //Checks if setName works correctly
     @Test
-    void testRoleModification() {
-        Role role = new Role(2L, "USER", null);
-        role.setName("MODERATOR");
-        assertEquals("MODERATOR", role.getName());
+    void getAllRoles() {
+        when(roleRepository.findAll()).thenReturn(List.of(role));
+
+        List<Role> roles = roleService.getAllRoles();
+
+        assertEquals(1, roles.size());
+        assertEquals("ADMIN", roles.get(0).getName());
+        verify(roleRepository, times(1)).findAll();
     }
+
+    @Test
+    void getRoleById() {
+        when(roleRepository.findById(1L)).thenReturn(Optional.of(role));
+
+        Optional<Role> retRole = roleService.getRoleById(1L);
+
+        assertTrue(retRole.isPresent());
+
+        assertEquals("ADMIN", role.getName());
+
+        verify(roleRepository, times(1)).findById(1L);
+    }
+
+    @Test
+    void createRole() {
+        when(roleRepository.save(role)).thenReturn(role);
+
+        Role savedRole = roleService.createRole(role);
+
+        assertNotNull(savedRole);
+        assertEquals("ADMIN", savedRole.getName());
+        verify(roleRepository, times(1)).save(role);
+    }
+
+    @Test
+    void deleteRole() {
+        doNothing().when(roleRepository).deleteById(1L);
+
+        roleService.deleteRole(1L);
+
+        verify(roleRepository, times(1)).deleteById(1L);
+    }
+
+    @Test
+    void updateRolePermissions() {
+
+        Set<String> newPermissions = Set.of("ROLE_MANAGEMENT", "EMPLOYEE_MANAGEMENT", "SHIFT_MANAGEMENT", "PROPOSAL_APPROVAL");
+
+        when(roleRepository.findById(1L)).thenReturn(Optional.of(role));
+
+        when(roleRepository.save(any(Role.class))).thenReturn(role);
+
+        Optional<Role> updatedRole = roleService.updateRolePermissions(1L, newPermissions);
+
+        assertTrue(updatedRole.isPresent());
+        assertEquals(4, updatedRole.get().getPermissions().size());
+
+        assertTrue(updatedRole.get().getPermissions().contains("SHIFT_MANAGEMENT"));
+        assertTrue(updatedRole.get().getPermissions().contains("PROPOSAL_APPROVAL"));
+        assertTrue(updatedRole.get().getPermissions().contains("ROLE_MANAGEMENT"));
+        assertTrue(updatedRole.get().getPermissions().contains("EMPLOYEE_MANAGEMENT"));
+
+        verify(roleRepository, times(1)).findById(1L);
+        verify(roleRepository, times(1)).save(role);
+    }
+
+    @Test
+    void getAllPermissions() {
+        Set<String> permissions = roleService.getAllPermissions();
+
+        assertEquals(9, permissions.size());
+        assertTrue(permissions.contains("ROLE_MANAGEMENT"));
+        assertTrue(permissions.contains("CALENDAR_VIEW"));
+    }
+
 }

--- a/planner-backend/modules/logicGate/src/main/java/com/LIT/logicGate/controller/LogicGateController.java
+++ b/planner-backend/modules/logicGate/src/main/java/com/LIT/logicGate/controller/LogicGateController.java
@@ -116,6 +116,7 @@ public class LogicGateController {
         String role = (String) requestWrap.getAttribute("role");
         String userName = (String) requestWrap.getAttribute("userName");
         Long userId = (Long) requestWrap.getAttribute("userId");
+        String permissions = (String) requestWrap.getAttribute("permissions");
         
         if(role != null){
             headers.set("X-User-Role", role);
@@ -127,6 +128,10 @@ public class LogicGateController {
 
         if(userId != null){
             headers.set("X-User-Id", userId.toString());
+        }
+
+        if(permissions != null){
+            headers.set("X-User-Permissions", permissions);
         }
         
         // Form entity to send for the request

--- a/planner-backend/modules/logicGate/src/main/java/com/LIT/logicGate/utilities/JwtAuthenticationFilter.java
+++ b/planner-backend/modules/logicGate/src/main/java/com/LIT/logicGate/utilities/JwtAuthenticationFilter.java
@@ -82,6 +82,7 @@ public class JwtAuthenticationFilter extends OncePerRequestFilter {
             String role = "ROLE_" + jwtTokenUtil.extractRole(token);
             Long userId = jwtTokenUtil.extractUserId(token);
             String userName = jwtTokenUtil.extractUsername(token);
+            String permissions = jwtTokenUtil.extractPermissions(token);
 
             log.info(logHeader + "User: " + userEmail + " has role: " + role + " and id: " + userId);
             log.info(logHeader + "Token is valid, proceeding with request");
@@ -95,8 +96,10 @@ public class JwtAuthenticationFilter extends OncePerRequestFilter {
             requestWrap.setAttribute("userName", userName);
             requestWrap.setAttribute("role", role);
             requestWrap.setAttribute("userId", userId);
+            requestWrap.setAttribute("permissions", permissions);
 
             log.info(logHeader + "User: " + userEmail + " is authenticated");
+            log.info(logHeader + "User has role: '" + role + "' and permissions: '" + permissions + "'");
 
             log.info(logHeader + "Request is authenticated, proceeding with request. " + requestWrap.getMethod() + " " + requestWrap.getRequestURI() + " " + requestWrap.getAttributeNames() + " " + requestWrap.getAttribute("userEmail") + " " + requestWrap.getAttribute("role"));
 

--- a/planner-backend/modules/logicGate/src/main/java/com/LIT/logicGate/utilities/JwtTokenUtil.java
+++ b/planner-backend/modules/logicGate/src/main/java/com/LIT/logicGate/utilities/JwtTokenUtil.java
@@ -21,7 +21,7 @@ public class JwtTokenUtil {
 
     private static final long EXPIRATION_TIME = 3600000; // 1 hour
 
-    public String generateToken(String email, String role, Long userId, String username) {
+    public String generateToken(String email, String role, Long userId, String username, String permissions) {
         log.info(logHeader + "generateToken: Generating token for user: " + email);        
         return JWT.create()
                 .withIssuer("LIT - auth0")
@@ -30,6 +30,7 @@ public class JwtTokenUtil {
                 .withClaim("role", role)
                 .withClaim("userName", username)
                 .withClaim("userId", userId)
+                .withClaim("permissions", permissions)
                 .withIssuedAt(new Date(System.currentTimeMillis()))
                 .withExpiresAt(new Date(System.currentTimeMillis() + EXPIRATION_TIME))
                 .sign(Algorithm.HMAC256(secret));
@@ -53,6 +54,11 @@ public class JwtTokenUtil {
     public String extractUsername(String token) {
         log.info(logHeader + "extractUsername: Extracting username from token");
         return JWT.decode(token).getClaim("userName").asString();
+    }
+
+    public String extractPermissions(String token) {
+        log.info(logHeader + "extractPermissions: Extracting permissions from token");
+        return JWT.decode(token).getClaim("permissions").asString();
     }
 
     public boolean validateToken(String token) {

--- a/planner-backend/modules/scheduler/src/main/java/com/LIT/scheduler/controller/ShiftProposalController.java
+++ b/planner-backend/modules/scheduler/src/main/java/com/LIT/scheduler/controller/ShiftProposalController.java
@@ -11,6 +11,10 @@ import org.springframework.security.access.method.P;
 import org.springframework.web.bind.annotation.*;
 
 import java.util.List;
+import java.util.Arrays;
+import java.util.Set;
+import java.util.stream.Collectors;
+
 
 @Slf4j
 @RestController
@@ -84,7 +88,7 @@ public class ShiftProposalController {
             return ResponseEntity.status(403).build();
         }
         
-        log.info(logHeader + "getAllProposals: Role has been verified, proceeding to get all proposals for: " + role);
+        log.info(logHeader + "getAllProposals: Permissions have been verified, proceeding to get all proposals for user with permissions: " + permissions);
 
         List<ShiftProposal> proposals = proposalService.getAllProposals();
 

--- a/planner-backend/modules/scheduler/src/main/java/com/LIT/scheduler/controller/ShiftProposalController.java
+++ b/planner-backend/modules/scheduler/src/main/java/com/LIT/scheduler/controller/ShiftProposalController.java
@@ -26,6 +26,12 @@ public class ShiftProposalController {
         this.proposalService = proposalService;
     }
 
+    private Set<String> getPermissions(String permissions) {
+        return Arrays.stream(permissions.split(","))
+                    .map(String::trim)
+                    .collect(Collectors.toSet());
+    }
+
     // Employee submits new shift proposal
     @PostMapping("/create")
     public ResponseEntity<ShiftProposal> createProposal(@RequestBody ShiftProposal proposal, @RequestHeader("X-User-Role") String role, @RequestHeader("X-User-Name") String username, @RequestHeader("X-User-Id") Long userId) {
@@ -60,11 +66,21 @@ public class ShiftProposalController {
 
     // Manager retrieves all proposals
     @GetMapping
-    public ResponseEntity<List<ShiftProposal>> getAllProposals(@RequestHeader("X-User-Role") String role) {
+    public ResponseEntity<List<ShiftProposal>> getAllProposals(@RequestHeader("X-User-Permissions") String permissions) {
         log.info(logHeader + "getAllProposals: Getting all proposals");
 
-        if(!role.equals("ROLE_Admin") && !role.equals("ROLE_Shift-Supervisor")) {
-            log.error(logHeader + "User is not authorized to view all proposals");
+        if(permissions == null || permissions.isEmpty()) {
+            log.error(logHeader + "getUserById: ERROR! User permissions are not provided in the header");
+
+            return ResponseEntity.badRequest().build();
+        }
+
+        Set<String> userPermissions = getPermissions(permissions);
+
+        if(!userPermissions.contains("PROPOSAL_APPROVAL")) {
+            log.error(logHeader + "getUserById: ERROR! User does not have permission to get user by id. The user permissions is: " + permissions);
+            log.info(logHeader + "The needed permission is: 'PROPOSAL_APPROVAL'");
+
             return ResponseEntity.status(403).build();
         }
         

--- a/planner-backend/modules/scheduler/src/main/java/com/LIT/scheduler/service/AuthUserService.java
+++ b/planner-backend/modules/scheduler/src/main/java/com/LIT/scheduler/service/AuthUserService.java
@@ -33,7 +33,7 @@ public class AuthUserService {
 
         // Set the header to a value allowed by the auth service.
         HttpHeaders headers = new HttpHeaders();
-        headers.set("X-User-Role", "ROLE_Admin"); // Use ROLE_Admin or ROLE_Shift-Supervisor as required
+        headers.set("X-User-Permissions", "EMPLOYEE_MANAGEMENT"); // Have the correct permissions
         log.debug("[AuthUserService] - Headers being sent: {}", headers);
 
         HttpEntity<?> entity = new HttpEntity<>(headers);

--- a/planner-backend/modules/scheduler/src/test/java/com/LIT/scheduler/AdditionalTests.java
+++ b/planner-backend/modules/scheduler/src/test/java/com/LIT/scheduler/AdditionalTests.java
@@ -170,7 +170,7 @@ public class AdditionalTests {
         // Set up the mock server expectation.
         localMockServer.expect(requestTo(new URI(expectedUrl)))
                 .andExpect(method(HttpMethod.GET))
-                .andExpect(header("X-User-Role", "ROLE_Admin"))
+                .andExpect(header("X-User-Permissions", "EMPLOYEE_MANAGEMENT"))
                 .andRespond(withSuccess(jsonResponse, MediaType.APPLICATION_JSON));
 
         // Call the method.


### PR DESCRIPTION
This pull request introduces significant changes to the authentication and authorization mechanisms in the `planner-backend` module. The primary focus is on replacing role-based access control with a more granular permission-based system. Key changes include updates to the `UserController`, `AuthenticationService`, `JwtTokenUtil`, and associated tests.

### Authentication and Authorization Updates:

* [`planner-backend/modules/auth/src/main/java/com/LIT/auth/controller/UserController.java`](diffhunk://#diff-dd4f273f9bdfd3ac2b9276d9b61ada1f5cc69af813dc119a60282d6aec093c05L16-R23): Updated methods to use permissions instead of roles for access control, added `getPermissions` helper method to parse permissions from headers. [[1]](diffhunk://#diff-dd4f273f9bdfd3ac2b9276d9b61ada1f5cc69af813dc119a60282d6aec093c05L16-R23) [[2]](diffhunk://#diff-dd4f273f9bdfd3ac2b9276d9b61ada1f5cc69af813dc119a60282d6aec093c05R45-R70) [[3]](diffhunk://#diff-dd4f273f9bdfd3ac2b9276d9b61ada1f5cc69af813dc119a60282d6aec093c05L79-R110)

* [`planner-backend/modules/auth/src/main/java/com/LIT/auth/service/AuthenticationService.java`](diffhunk://#diff-2142179ba3992c1d6024705f312286cf76460a3e1a73e43087aa4f3919137700L178-R176): Modified `login` and `register` methods to include permissions in the generated token. [[1]](diffhunk://#diff-2142179ba3992c1d6024705f312286cf76460a3e1a73e43087aa4f3919137700L178-R176) [[2]](diffhunk://#diff-2142179ba3992c1d6024705f312286cf76460a3e1a73e43087aa4f3919137700L241-R239)

* [`planner-backend/modules/auth/src/main/java/com/LIT/auth/utilities/JwtTokenUtil.java`](diffhunk://#diff-8466a318d91ae85da96bcde56d43072f0ed422b7a0856b6385796509ca5ca02bL24-R24): Added permissions claim to JWT token generation and extraction methods. [[1]](diffhunk://#diff-8466a318d91ae85da96bcde56d43072f0ed422b7a0856b6385796509ca5ca02bL24-R24) [[2]](diffhunk://#diff-8466a318d91ae85da96bcde56d43072f0ed422b7a0856b6385796509ca5ca02bR33) [[3]](diffhunk://#diff-8466a318d91ae85da96bcde56d43072f0ed422b7a0856b6385796509ca5ca02bR59-R63)

### Test Updates:

* [`planner-backend/modules/auth/src/test/java/com/LIT/auth/tests/controller/UserControllerTest.java`](diffhunk://#diff-3836d81e8a7f05dbcc95217f95c9c0736bc30d3828aa319e9e71e283d4703be1L43-R43): Updated tests to reflect changes from role-based to permission-based access control. [[1]](diffhunk://#diff-3836d81e8a7f05dbcc95217f95c9c0736bc30d3828aa319e9e71e283d4703be1L43-R43) [[2]](diffhunk://#diff-3836d81e8a7f05dbcc95217f95c9c0736bc30d3828aa319e9e71e283d4703be1L57-R59) [[3]](diffhunk://#diff-3836d81e8a7f05dbcc95217f95c9c0736bc30d3828aa319e9e71e283d4703be1L74-R74) [[4]](diffhunk://#diff-3836d81e8a7f05dbcc95217f95c9c0736bc30d3828aa319e9e71e283d4703be1L88-R88) [[5]](diffhunk://#diff-3836d81e8a7f05dbcc95217f95c9c0736bc30d3828aa319e9e71e283d4703be1L103-R105)

* [`planner-backend/modules/auth/src/test/java/com/LIT/auth/tests/unittests/RoleTest.java`](diffhunk://#diff-e7dffedfd2f5f00dec9c1f4f896752bc900d8393f74ff05439cf4be579aa644cL3-R117): Added new unit tests for role service methods, including CRUD operations and permission updates.

### Additional Changes:

* [`planner-backend/modules/logicGate/src/main/java/com/LIT/logicGate/controller/LogicGateController.java`](diffhunk://#diff-a70184ad2e754d301be352b2cfd018c4b21f540e9ddc77b4a00b48433f2c0581R119): Forward user permissions in the request headers. [[1]](diffhunk://#diff-a70184ad2e754d301be352b2cfd018c4b21f540e9ddc77b4a00b48433f2c0581R119) [[2]](diffhunk://#diff-a70184ad2e754d301be352b2cfd018c4b21f540e9ddc77b4a00b48433f2c0581R133-R136)

* [`planner-backend/modules/logicGate/src/main/java/com/LIT/logicGate/utilities/JwtAuthenticationFilter.java`](diffhunk://#diff-c6cb6ca20ddebbffef649ebb0738063c97986796c04bbf2c3f2c8e11ebaccac5R85): Extract permissions from the JWT token and set them as request attributes. [[1]](diffhunk://#diff-c6cb6ca20ddebbffef649ebb0738063c97986796c04bbf2c3f2c8e11ebaccac5R85) [[2]](diffhunk://#diff-c6cb6ca20ddebbffef649ebb0738063c97986796c04bbf2c3f2c8e11ebaccac5R99-R102)

* [`planner-backend/modules/logicGate/src/main/java/com/LIT/logicGate/utilities/JwtTokenUtil.java`](diffhunk://#diff-18648bd9229d9b5946e8aa5494c4d21a98a8537d7b04a94017efc83618402280L24-R24): Updated token generation to include permissions. [[1]](diffhunk://#diff-18648bd9229d9b5946e8aa5494c4d21a98a8537d7b04a94017efc83618402280L24-R24) [[2]](diffhunk://#diff-18648bd9229d9b5946e8aa5494c4d21a98a8537d7b04a94017efc83618402280R33)